### PR TITLE
fix: stream.end not called

### DIFF
--- a/log.js
+++ b/log.js
@@ -315,8 +315,6 @@ LogStream.prototype.end = function (cb) {
   }
   // avoid call stream.end twice
   if (stream) {
-    stream.uncork();
-    stream.removeAllListeners();
     stream.end(function () {
       if (stream.close) {
         stream.close(cb);


### PR DESCRIPTION
fix #2 

calling end will flush data so there is no need for uncork

> The buffered data will be flushed when either the stream.uncork() or stream.end() methods are called.

ref: https://nodejs.org/dist/latest-v6.x/docs/api/stream.html#stream_writable_cork